### PR TITLE
Optional audit logging

### DIFF
--- a/afrims/localsettings.py.example
+++ b/afrims/localsettings.py.example
@@ -116,3 +116,12 @@ COUNTRY_CODE = '1'
 # INSTALLED_APPS = list(INSTALLED_APPS)
 # INSTALLED_APPS.append('debug_toolbar')
 # DEBUG_TOOLBAR_CONFIG = {'INTERCEPT_REDIRECTS': False}
+
+# Remove auditcare/couchlog settings to disable auditing locally
+INSTALLED_APPS.remove('auditcare')
+INSTALLED_APPS.remove('couchlog')
+MIDDLEWARE_CLASSES.remove('auditcare.middleware.AuditMiddleware')
+AUDIT_DJANGO_USER = False
+AUDIT_ALL_VIEWS = False
+AUDIT_VIEWS = []
+AUDIT_MODEL_SAVE = []

--- a/afrims/test_localsettings.py.example
+++ b/afrims/test_localsettings.py.example
@@ -42,3 +42,14 @@ ADMINS = (
     ('Development Team', 'afrims-dev@dimagi.com'),
 )
 MANAGERS = ADMINS
+
+LANGUAGE_CODE = 'en'
+
+# Disable audit logging while running the test suite
+INSTALLED_APPS.remove('auditcare')
+INSTALLED_APPS.remove('couchlog')
+MIDDLEWARE_CLASSES.remove('auditcare.middleware.AuditMiddleware')
+AUDIT_DJANGO_USER = False
+AUDIT_ALL_VIEWS = False
+AUDIT_VIEWS = []
+AUDIT_MODEL_SAVE = []

--- a/afrims/urls.py
+++ b/afrims/urls.py
@@ -13,8 +13,7 @@ urlpatterns = patterns('',
     # (r'^admin/doc/', include('django.contrib.admindocs.urls')),
 
     (r'^admin/', include(admin.site.urls)),
-    (r'^', include('auditcare.urls')),
-    
+
     # RapidSMS core URLs
     (r'^account/', include('rapidsms.urls.login_logout')),
     url(r'^$', 'afrims.apps.broadcast.views.dashboard', name='rapidsms-dashboard'),
@@ -38,9 +37,19 @@ urlpatterns = patterns('',
     (r'^test-messager/', include('afrims.apps.test_messager.urls')),
     (r'^crm/', include('afrims.apps.groups.urls')),
     (r'^rosetta/', include('rosetta.urls')),
-    (r'^couchlog/', include('couchlog.urls')),
     (r'^i18n/', include('django.conf.urls.i18n')),
 )
+
+if 'auditcare' in settings.INSTALLED_APPS:
+    urlpatterns += patterns('',
+        (r'^', include('auditcare.urls')),
+    )
+
+if 'couchlog' in settings.INSTALLED_APPS:
+    urlpatterns += patterns('',
+        (r'^couchlog/', include('couchlog.urls')),
+    )
+
 
 if settings.DEBUG:
     urlpatterns += patterns('',


### PR DESCRIPTION
Seems someone else had the same idea as me in #1. This allows the auditcare and couchdb logging to be disabled for local development and unittesting.
