### PR TITLE
Simple Survey

### DIFF
--- a/afrims/apps/overrides/__init__.py
+++ b/afrims/apps/overrides/__init__.py
@@ -1,0 +1,1 @@
+"This app contains overrides and extensions to third-party applications."

--- a/afrims/apps/overrides/admin.py
+++ b/afrims/apps/overrides/admin.py
@@ -1,0 +1,25 @@
+"Changes to third-party admin registrations."
+
+from django.contrib import admin
+from django.core.urlresolvers import reverse
+
+from decisiontree import models
+
+# Change tree registration to be more helpful
+admin.site.unregister(models.Tree)
+
+
+class TreeAdmin(admin.ModelAdmin):
+    "Fancier DecisionTree admin."
+
+    list_display = ('__unicode__', 'trigger', 'root_state', 'report_data', )
+
+    def report_data(self, obj):
+        "Link to download the report data."
+        url = reverse('export_tree', args=[obj.pk])
+        return u"<a href='{0}'>Download Results Report</a>".format(url)
+    report_data.allow_tags = True
+    report_data.short_description = u"Results Report"
+
+
+admin.site.register(models.Tree, TreeAdmin)

--- a/afrims/apps/overrides/admin.py
+++ b/afrims/apps/overrides/admin.py
@@ -7,6 +7,15 @@ from decisiontree import models
 
 # Change tree registration to be more helpful
 admin.site.unregister(models.Tree)
+admin.site.unregister(models.Question)
+admin.site.unregister(models.TreeState)
+admin.site.unregister(models.Answer)
+admin.site.unregister(models.Session)
+# I don't think we have a need for these so let's not clutter the admin
+admin.site.unregister(models.Tag)
+admin.site.unregister(models.TagNotification)
+# There isn't a good use-case for modifying user's answers
+admin.site.unregister(models.Entry)
 
 
 class TreeAdmin(admin.ModelAdmin):
@@ -22,4 +31,58 @@ class TreeAdmin(admin.ModelAdmin):
     report_data.short_description = u"Results Report"
 
 
+class StateInline(admin.StackedInline):
+    "Allow adding a tree state when adding a question."
+
+    model = models.TreeState
+    extra = 0
+
+
+class QuestionAdmin(admin.ModelAdmin):
+    "Edit questions with inlines to TreeStates."
+
+    inlines = (StateInline, )
+
+
+class TransistionInline(admin.StackedInline):
+    "Allow adding a transistion when adding an answer."
+
+    model = models.Transition
+    extra = 0
+
+
+class AnswerAdmin(admin.ModelAdmin):
+    "Edit answers with inlines to answers."
+
+    list_display = ('name', 'type', 'answer', )
+    list_filter = ('type', )
+    inlines = (TransistionInline, )
+
+
+class StateTransistionInline(TransistionInline):
+    "Transision has more than FK to state so set fk_name."
+    fk_name = 'current_state'
+
+
+class StateAdmin(admin.ModelAdmin):
+    "Edit states with inlines to transisions."
+    
+    list_display = ('name', 'question', )
+    inlines = (StateTransistionInline, )
+
+
+class SessionAdmin(admin.ModelAdmin):
+    "List sessions with better filtering."
+    list_display = ('connection', 'tree', 'current_state', 'start_date', 'last_modified', )
+    list_filter = ('start_date', 'last_modified', 'tree', )
+
+    def current_state(self, obj):
+        "Display current question or note if they have completed the questions."
+        return obj.state if obj.state else "completed"
+    
+
 admin.site.register(models.Tree, TreeAdmin)
+admin.site.register(models.Question, QuestionAdmin)
+admin.site.register(models.Answer, AnswerAdmin)
+admin.site.register(models.TreeState, StateAdmin)
+admin.site.register(models.Session, SessionAdmin)

--- a/afrims/apps/overrides/admin.py
+++ b/afrims/apps/overrides/admin.py
@@ -61,6 +61,7 @@ class AnswerAdmin(admin.ModelAdmin):
 
 class StateTransistionInline(TransistionInline):
     "Transision has more than FK to state so set fk_name."
+
     fk_name = 'current_state'
 
 
@@ -73,6 +74,7 @@ class StateAdmin(admin.ModelAdmin):
 
 class SessionAdmin(admin.ModelAdmin):
     "List sessions with better filtering."
+
     list_display = ('connection', 'tree', 'current_state', 'start_date', 'last_modified', )
     list_filter = ('start_date', 'last_modified', 'tree', )
 

--- a/afrims/settings.py
+++ b/afrims/settings.py
@@ -60,6 +60,8 @@ INSTALLED_APPS = [
     "rapidsms.contrib.registration",
     "rapidsms.contrib.scheduler",
 
+    "decisiontree",
+
     "couchlog",
 
     # this app should be last, as it will always reply with a help message
@@ -271,3 +273,5 @@ SERVER_EMAIL = "afrims-dev@dimagi.com"
 
 NO_LOGIN_REQUIRED_FOR = ["/reminders/post",
                          "/reminders/post/"]
+
+DECISIONTREE_SESSION_END_TRIGGER = '#makeitstop'

--- a/afrims/settings.py
+++ b/afrims/settings.py
@@ -66,6 +66,7 @@ INSTALLED_APPS = [
 
     # this app should be last, as it will always reply with a help message
     "afrims.apps.catch_all",
+    "afrims.apps.overrides",
 ]
 
 

--- a/afrims/urls.py
+++ b/afrims/urls.py
@@ -17,6 +17,8 @@ urlpatterns = patterns('',
     url(r'^access_denied/$', direct_to_template,
         {'template': 'afrims/access_denied.html'}, name='access-denied'),
 
+    url(r'^survey/export/(?P<tree_id>\d+)/$', 'decisiontree.views.export', name='export_tree'),
+
     # RapidSMS contrib app URLs
     (r'^ajax/', include('rapidsms.contrib.ajax.urls')),
     (r'^export/', include('rapidsms.contrib.export.urls')),
@@ -31,7 +33,7 @@ urlpatterns = patterns('',
     (r'^test-messager/', include('afrims.apps.test_messager.urls')),
     (r'^crm/', include('afrims.apps.groups.urls')),
     (r'^rosetta/', include('rosetta.urls')),
-    (r'^i18n/', include('django.conf.urls.i18n')),
+    (r'^i18n/', include('django.conf.urls.i18n')),    
     (r'^', include('afrims.apps.reports.urls')),
 )
 

--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -3,19 +3,20 @@ South==0.7.3
 gunicorn==0.12.0
 python-dateutil==1.5
 nose==1.0
--e git+http://github.com/dimagi/rapidsms.git#egg=rapidsms
--e git+http://github.com/adammck/djtables#egg=djtables
 django-pagination==1.0.7
 lxml==2.3
 twilio==2.0.6
--e git+http://github.com/caktus/rapidsms-twilio.git@ac99162da98303b63775#egg=rtwilio
 django-sorting==0.1
 psycopg2==2.4
 django-staticfiles==1.0
 django-rosetta==0.6.0
--e git+https://github.com/dimagi/rapidsms-mach-backend.git#egg=rmach
 couchdbkit==0.5.4
-pytz
+pytz==2012c
+-e git+http://github.com/dimagi/rapidsms.git#egg=rapidsms
+-e git+http://github.com/adammck/djtables#egg=djtables
+-e git+http://github.com/caktus/rapidsms-twilio.git@ac99162da98303b63775#egg=rtwilio
+-e git+https://github.com/dimagi/rapidsms-mach-backend.git#egg=rmach
 -e git+https://github.com/dimagi/couchlog.git#egg=couchlog
 -e git+https://github.com/dimagi/auditcare.git#egg=auditcare
 -e git+https://github.com/dimagi/dimagi-utils.git#egg=dimagi_utils
+-e git+https://github.com/caktus/rapidsms-decisiontree-app.git@develop#egg=decisiontree


### PR DESCRIPTION
This change integrates the latest changes from [rapidsms-decisiontree](https://github.com/caktus/rapidsms-decisiontree-app) into TrialConnect to allow for setting up a user survey. Creating a survey is a somewhat involved process but there are some admin customizations here to make it a little easier. We are working on some documentation in the `decisiontree` project as well.

There might be an ordering issue on how the responses are handled. The `reminders` app will process incoming messages prior to `decisiontree`. It would be good to know the types of questions and answers here so we can sort those out prior to this being deployed.

Triggering the start of the survey is something else that is worth discussing. My thought was that the easiest way would be to send a broadcast to whomever is supposed to take the survey with something to the effect of

> We are conducting a survey on TC usage. Please text survey-1 to start the survey

The survey results are available in a CSV download via the admin.
