### PR TITLE
Invalid Report Date Error

### DIFF
--- a/afrims/apps/reports/templates/reports/dashboard.html
+++ b/afrims/apps/reports/templates/reports/dashboard.html
@@ -132,7 +132,7 @@
         </tr>
     </table>
 </div>
-<div id='usage-chart' style="width: 900px; height: 240px;" data-url="{% url report-system-usage %}?months=8&start_date={{ report_date }}"></div>
+<div id='usage-chart' style="width: 900px; height: 240px;" data-url="{% url report-system-usage %}?months=8&start_date={{ report_date.isoformat }}"></div>
 <div class="module">
     <table id="reminders-table" class="full-width">
         <thead>
@@ -169,7 +169,7 @@
         </tr>
     </table>
 </div>
-<div id='reminders-chart' style="width: 900px; height: 240px;" data-url="{% url report-reminder-usage %}?months=8&start_date={{ report_date }}"></div>
+<div id='reminders-chart' style="width: 900px; height: 240px;" data-url="{% url report-reminder-usage %}?months=8&start_date={{ report_date.isoformat }}"></div>
 <div class="module">
     <table id="broadcasts-table" class="full-width">
         <thead>

--- a/afrims/apps/reports/tests/test_views.py
+++ b/afrims/apps/reports/tests/test_views.py
@@ -375,6 +375,15 @@ class ReminderGraphViewTest(BaseGraphViewTest):
         self.assertTrue('range' in results)
         self.assertEqual(len(results['range']), 5) # Current month + 4
 
+    def test_invalid_range(self):
+        "Ask for invalid date range."
+        response = self.client.get(self.url, {'months': 'XXX'})
+        self.assertEqual(response.status_code, 400)
+        results = json.loads(response.content)
+        self.assertFalse('to_date' in results)
+        self.assertFalse('range' in results)
+
+
 class UsageGraphViewTest(BaseGraphViewTest):
     "View for generating data for the system usage graphs."
 
@@ -391,3 +400,11 @@ class UsageGraphViewTest(BaseGraphViewTest):
         self.assertFalse('to_date' in results)
         self.assertTrue('range' in results)
         self.assertEqual(len(results['range']), 5) # Current month + 4
+
+    def test_invalid_range(self):
+        "Ask for invalid date range."
+        response = self.client.get(self.url, {'months': 'XXX'})
+        self.assertEqual(response.status_code, 400)
+        results = json.loads(response.content)
+        self.assertFalse('to_date' in results)
+        self.assertFalse('range' in results)

--- a/afrims/apps/reports/views.py
+++ b/afrims/apps/reports/views.py
@@ -3,7 +3,7 @@ import datetime
 
 from django.contrib.auth.decorators import login_required, permission_required
 from django.db.models import Count, Q
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils import simplejson as json
 from django.views.generic.simple import direct_to_template as render
 
@@ -75,6 +75,8 @@ def reminder_usage(request):
     if range_form.is_valid():
         start_date = range_form.cleaned_data.get('start_date', None)
         months = range_form.cleaned_data.get('months', None)
+    else:
+        return HttpResponseBadRequest(json.dumps({'error': 'Invalid report range'}), mimetype='application/json')
     if start_date is not None and months is not None:
         # Generate report for each month requested
         rows = []
@@ -101,6 +103,8 @@ def system_usage(request):
     if range_form.is_valid():
         start_date = range_form.cleaned_data.get('start_date', None)
         months = range_form.cleaned_data.get('months', None)
+    else:
+        return HttpResponseBadRequest(json.dumps({'error': 'Invalid report range'}), mimetype='application/json')
     if start_date is not None and months is not None:
         # Generate report for each month requested
         rows = []


### PR DESCRIPTION
Previously the dashboard was using an ambiguous date format to request the graph data start date/month range. When there was an invalid date format given it would not return the expected data and break the graph rendering with an unclear error "Cannot read propertt 'length' of undefined." This change changes the date format to use the ISO format and when an invalid range it requested the server responds with a more meaningful status code (400 Bad Request). 
